### PR TITLE
#7 additional files are now published

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -15,6 +15,14 @@ var apps = getProjectsDirs(new string [] {
     "OS.Smog.Api"
 });
 
+var includeFiles = new Dictionary<string, string[]>(){
+    {
+        "OS.Smog.Api", new[] {
+            "OS.Smog.Api.xml"
+        }
+    }
+};
+
 Task(Clean)
     .WithCriteria(DirectoryExists(ArtifactsDir))
     .Does(() => {
@@ -63,6 +71,10 @@ Task(Publish)
     .Does(() => {
     forEachPath(apps, null, (app) => {
         DotNetCorePublish(app, getDotNetCorePublishSettings(app));
+    });
+
+    forEachPath(apps, getProjectName, (app) => {
+        publishFiles(app, includeFiles);
     });
 }); // Publish
 

--- a/build/settings.build.cake
+++ b/build/settings.build.cake
@@ -67,4 +67,18 @@ var forEachPath = new Action<IEnumerable<string>, Func<string, string>, Action<s
     }
 });
 
+var publishFiles = new Action<string, Dictionary<string, string[]>>((app, includeFiles) => {
+    if(includeFiles.ContainsKey(app)) {
+        Information($"\nPublishing additional files for {app}:");
+
+        foreach(var file in includeFiles[app]) {
+            var from = $"./src/{app}/bin/{@configuration}/netcoreapp1.1/{file}";
+            var to = $"{ArtifactsDir}/apps/{app}";
+
+            Information($"\t{file} -> {to}");
+            CopyFileToDirectory(from, to);
+        }
+    }
+});
+
 #load settings.netcore.cake

--- a/src/OS.Smog.Api/OS.Smog.Api.csproj
+++ b/src/OS.Smog.Api/OS.Smog.Api.csproj
@@ -11,6 +11,10 @@
     <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netcoreapp1.1\OS.Smog.Api.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
@@ -34,5 +38,4 @@
     <ProjectReference Include="..\OS.Smog.Domain\OS.Smog.Domain.csproj" />
     <ProjectReference Include="..\OS.Smog.Dto\OS.Smog.Dto.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
CAKE Publish Task is now capable of publishing additional custom files.

- Fixes the issue where XML docs needed by swagger are not being published to output